### PR TITLE
fix: accept fileItem only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ lib
 lib-esm
 docs
 src/test.ts
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "cSpell.words": ["voltammetry"]
-}

--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ import { convert as cv } from 'biologic-converter';
 
 async function run() {
   /* path to the root dir of experiments or any child */
-  const fl = fileCollectionFromPath(join(__dirname, 'data'));
-
-  const experiments = await cv(fl); //array of directories
-
+  const fc = fileCollectionFromPath(join(__dirname, 'data'));
+  const experiments = [];
+  for (const experiment of fc.files) {
+    const rawData = await experiment.arrayBuffer();
+    const result = await cv(rawData); //result or undefined
+    if (result) experiments.push(result);
+  }
   return experiments;
 }
 

--- a/src/__tests__/__snapshots__/convert.test.ts.snap
+++ b/src/__tests__/__snapshots__/convert.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test convert compare parsers cp.[mpt,mpr] 1`] = `
+exports[`test convert compare parsers cp.{mpt,mpr} 1`] = `
 {
   "data": {
     "header": {
@@ -1420,7 +1420,7 @@ exports[`test convert compare parsers cp.[mpt,mpr] 1`] = `
         "units": "",
       },
       "u": {
-        "data": [
+        "data": Float64Array [
           0,
           0,
           0,
@@ -1548,7 +1548,7 @@ exports[`test convert compare parsers cp.[mpt,mpr] 1`] = `
         "units": "flag",
       },
       "v": {
-        "data": [
+        "data": Float64Array [
           0,
           0,
           0,
@@ -1676,7 +1676,7 @@ exports[`test convert compare parsers cp.[mpt,mpr] 1`] = `
         "units": "flag",
       },
       "w": {
-        "data": [
+        "data": Float64Array [
           0,
           0,
           0,
@@ -1804,7 +1804,7 @@ exports[`test convert compare parsers cp.[mpt,mpr] 1`] = `
         "units": "flag",
       },
       "x": {
-        "data": [
+        "data": Float64Array [
           0,
           0,
           0,
@@ -1932,7 +1932,7 @@ exports[`test convert compare parsers cp.[mpt,mpr] 1`] = `
         "units": "flag",
       },
       "y": {
-        "data": [
+        "data": Float64Array [
           0,
           0,
           0,
@@ -2060,7 +2060,7 @@ exports[`test convert compare parsers cp.[mpt,mpr] 1`] = `
         "units": "flag",
       },
       "z": {
-        "data": [
+        "data": Float64Array [
           1,
           1,
           1,

--- a/src/__tests__/convert.test.ts
+++ b/src/__tests__/convert.test.ts
@@ -5,51 +5,15 @@ import { fileCollectionFromPath } from 'filelist-utils';
 import { convert } from '../convert';
 
 describe('test convert', () => {
-  it('parses directory', async () => {
-    const fc = await fileCollectionFromPath(
-      join(__dirname, 'data/testDirectory'),
-    );
-    const directories = await convert(fc);
-    expect(directories).toHaveLength(3);
-    expect(directories).toMatchObject([
-      {
-        dir: 'testDirectory/ca',
-        mpr: {
-          name: 'BIO-LOGIC MODULAR FILE',
-        },
-        mpt: { name: 'EC-Lab ASCII FILE' },
-      },
-      {
-        dir: 'testDirectory/jdb11-1',
-        mpr: {
-          name: 'BIO-LOGIC MODULAR FILE',
-        },
-        mps: { name: 'EC-LAB SETTING FILE' },
-      },
-      {
-        dir: 'testDirectory/jdb11-4',
-        mpr: {
-          name: 'BIO-LOGIC MODULAR FILE',
-        },
-      },
-    ]);
-  });
-
-  it('passing a not-biologic dir should give []', async () => {
-    const fl = await fileCollectionFromPath(
-      join(__dirname, 'data/not-biologic'),
-    );
-    const directories = await convert(fl);
-    expect(directories).toStrictEqual([]);
-  });
-
-  it('compare parsers cp.[mpt,mpr]', async () => {
+  it('compare parsers cp.{mpt,mpr}', async () => {
     const fc = await fileCollectionFromPath(
       join(__dirname, 'data/compareParsers'),
     );
-    const directory = await convert(fc);
-    expect(directory).toHaveLength(1);
-    const { mpr, mpt } = directory[0];
+    const mprFile = fc.files.filter((f) => f.name.endsWith('.mpr'))[0];
+    const mptFile = fc.files.filter((f) => f.name.endsWith('.mpt'))[0];
+    const mpr = (await convert(mprFile))?.mpr;
+    const mpt = (await convert(mptFile))?.mpt;
+
     expect(mpr?.name).toBe('BIO-LOGIC MODULAR FILE');
     expect(mpt?.name).toBe('EC-Lab ASCII FILE');
 

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,64 +1,17 @@
-import { FileCollection, groupFiles } from 'filelist-utils';
+import { FileCollectionItem } from 'filelist-utils';
 
-import { ComplexObject } from './Types';
-import { MPR, parseMPR } from './mpr/parseMPR';
+import { parseMPR } from './mpr/parseMPR';
 import { parseMPS } from './mps/parseMPS';
-import { MPT, parseMPT } from './mpt/parseMPT';
+import { parseMPT } from './mpt/parseMPT';
 
-/**
- * Text files have no type at the moment, but they
- * follow MPR as much as possible
- */
-export interface Biologic {
-  dir?: string;
-  mpr?: MPR;
-  mps?: ComplexObject;
-  mpt?: MPT;
-}
-
-/**
- *  Parses Biologic mpr, mpt, mps formats from multiple or single directories.
- *  The result contains an array of [[`Biologic`]] `[{dir:'1', mps, mpt}, {dir:'2', mps, mpt},..]`
- *
- *  Project structure example:
- *
- *  ```text
- *├── parent
- *│  ├── child1
- *│  │  ├── jdb11-1.mpr
- *│  │  └── jdb11-1.mps
- *   ...
- *│  └── childN
- *│      ├── test.mpr
- *│      ├── test.mps
- *│      └── test.mpt
- *  ```
- *
- * @param fileCol - `path/to/parent` or `path/to/any/child`. (See tree above.)
- * @returns JSON object passing **child** directory; array of children if you pass a **parent**.
- */
-
-export async function convert(fileCol: FileCollection): Promise<Biologic[]> {
-  const dirs = groupFiles(fileCol);
-  let results: Biologic[] = [];
-
-  /* can not use `forEach` and pass `async` functions */
-  for (const dir of dirs) {
-    let result: Biologic = {};
-    result.dir = dir.key;
-    for (const dataFile of dir.fileCollection) {
-      const fName = dataFile.name;
-      if (fName.endsWith('.mps')) {
-        result.mps = parseMPS(await dataFile.arrayBuffer());
-      } else if (fName.endsWith('.mpt')) {
-        result.mpt = parseMPT(await dataFile.arrayBuffer());
-      } else if (fName.endsWith('.mpr')) {
-        result.mpr = parseMPR(await dataFile.arrayBuffer());
-      }
-    }
-    if (Object.keys(result).length > 1) {
-      results.push(result);
-    }
+export async function convert(file: FileCollectionItem) {
+  if (file.name.endsWith('.mps')) {
+    return { mps: parseMPS(await file.arrayBuffer()) };
+  } else if (file.name.endsWith('.mpt')) {
+    return { mpt: parseMPT(await file.arrayBuffer()) };
+  } else if (file.name.endsWith('.mpr')) {
+    return { mpr: parseMPR(await file.arrayBuffer()) };
+  } else {
+    return undefined;
   }
-  return results;
 }

--- a/src/mpr/modules/parseData.ts
+++ b/src/mpr/modules/parseData.ts
@@ -35,7 +35,7 @@ export function parseData(buffer: IOBuffer, header: ModuleHeader): ParseData {
         label: flagCol.name,
         units: 'flag',
         isDependent: false,
-        data: [],
+        data: new Float64Array(dataPoints),
       };
     }
   }


### PR DESCRIPTION
The idea is that the biologic parser only takes one `FileCollectionItem` at a time instead of an array of directories, in this way, we can have better control over errors while the same functionality is available. It parses files according to the extension.

So now we can read `fileCollectionFromPath`, and iterate over the files, and if we want to we can still group or filter files before passing to the converter. This is update in the README.md
