### PR TITLE
feat: append logs to output

### DIFF
--- a/src/__tests__/convert.test.ts
+++ b/src/__tests__/convert.test.ts
@@ -10,8 +10,7 @@ describe('test convert', () => {
   it('parse ca directory', async () => {
     const fc = await fileCollectionFromPath(join(testFiles, 'all', 'ca'));
     const directory = await convert(fc);
-    expect(directory).toHaveLength(1);
-    expect(directory).toMatchObject([
+    expect(directory.data).toMatchObject([
       {
         dir: 'ca',
         mpr: {
@@ -20,19 +19,42 @@ describe('test convert', () => {
         mpt: { name: 'EC-Lab ASCII FILE' },
       },
     ]);
+    expect(directory.logs).toHaveLength(1);
   });
 
   it('passing a not-biologic dir should give []', async () => {
     const fc = await fileCollectionFromPath(join(testFiles, 'not-biologic'));
     const directories = await convert(fc);
-    expect(directories).toStrictEqual([]);
+    expect(directories.data).toStrictEqual([]);
+    expect(directories.logs[0]).toMatchObject({
+      parser: 'biologic-converter',
+      kind: 'summary',
+    });
+  });
+
+  it('Not implemented experiment logs', async () => {
+    const fc = await fileCollectionFromPath(join(testFiles, 'all', 'geis'));
+    const directories = await convert(fc);
+    expect(directories.data).toStrictEqual([]);
+    expect(directories.logs).toHaveLength(2);
+    const error = directories.logs.find((log) => log.kind === 'error');
+    const summary = directories.logs.find((log) => log.kind === 'summary');
+    expect(error).toMatchObject({
+      parser: 'biologic-converter',
+      kind: 'error',
+      relativePath: 'geis/geis.mpt',
+    });
+    expect(summary).toMatchObject({
+      parser: 'biologic-converter',
+      kind: 'summary',
+    });
   });
 
   it('compare parsers cp.[mpt,mpr]', async () => {
     const fc = await fileCollectionFromPath(join(testFiles, 'all', 'cp'));
     const directory = await convert(fc);
-    expect(directory).toHaveLength(1);
-    const { mpr, mpt } = directory[0];
+    expect(directory.data).toHaveLength(1);
+    const { mpr, mpt } = directory.data[0];
     expect(mpr?.name).toBe('BIO-LOGIC MODULAR FILE');
     expect(mpt?.name).toBe('EC-Lab ASCII FILE');
 

--- a/src/utility/__tests__/createParserLog.test.ts
+++ b/src/utility/__tests__/createParserLog.test.ts
@@ -1,0 +1,26 @@
+import { createLogEntry } from '../createParserLog';
+
+describe('createLogEntry', () => {
+  it('no arguments', () => {
+    const log = createLogEntry({});
+    expect(log).toStrictEqual({
+      parser: 'biologic-converter',
+      kind: 'error',
+      message: 'Error parsing biologic experiment.',
+    });
+  });
+  it('error', () => {
+    const log = createLogEntry({
+      error: new Error('Help!'),
+      relativePath: '/tmp/foo',
+      parser: 'another-parser',
+    });
+    expect(log).toStrictEqual({
+      parser: 'another-parser',
+      kind: 'error',
+      message: 'Error parsing biologic experiment.',
+      relativePath: '/tmp/foo',
+      error: new Error('Help!'),
+    });
+  });
+});

--- a/src/utility/createParserLog.ts
+++ b/src/utility/createParserLog.ts
@@ -1,0 +1,29 @@
+export interface ParserLog {
+  kind: 'error' | 'warn' | 'info' | 'debug' | 'summary';
+  parser: string;
+  message: string;
+  relativePath?: string;
+  error?: Error;
+}
+
+export function createLogEntry(info: Partial<ParserLog>): ParserLog {
+  const {
+    parser = 'biologic-converter',
+    kind = 'error',
+    message = 'Error parsing biologic experiment.',
+  } = info;
+
+  const log: ParserLog = {
+    parser,
+    kind,
+    message,
+  };
+
+  if (info.error) {
+    log.error = info.error;
+  }
+  if (info.relativePath) {
+    log.relativePath = info.relativePath;
+  }
+  return log;
+}


### PR DESCRIPTION
The returned data structure is:
```
Convert {
  data: Biologic[ ];
  logs: ParserLog[ ]
}
```
Added a "summary" to the kind, I thought it was nice but if it is useless we can remove it. ATM it writes how many directories, successfully parsed files and errors were.

I think we can close #7  and #1 as well. We just will need more techniques once we get some stuff plotted.